### PR TITLE
Change username to identity

### DIFF
--- a/docs/book/v1/config.md
+++ b/docs/book/v1/config.md
@@ -52,6 +52,8 @@ return [
     ],
 
     'authentication' => [
+        'identity' => 'identity field name',
+        'password' => 'password field name',
         'redirect' => '/login',
     ],
 ];

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -16,14 +16,14 @@ class ConfigProvider
     {
         return [
             'authentication' => $this->getAuthenticationConfig(),
-            'dependencies' => $this->getDependencies(),
+            'dependencies'   => $this->getDependencies(),
         ];
     }
 
     public function getAuthenticationConfig() : array
     {
         return [
-            'username' => null,
+            'identity' => null,
             'password' => null,
         ];
     }

--- a/src/PhpSession.php
+++ b/src/PhpSession.php
@@ -167,7 +167,7 @@ class PhpSession implements AuthenticationInterface
             trigger_error(sprintf(
                 '%s is currently using an old configuration. The username is deprecated and has an identity instead; '
                 . 'please update your authentication configuration.',
-                __CLASS__,
+                __CLASS__
             ), E_USER_DEPRECATED);
         }
     }

--- a/test/PhpSessionTest.php
+++ b/test/PhpSessionTest.php
@@ -147,7 +147,7 @@ class PhpSessionTest extends TestCase
             ->willReturn(false);
         $this->session
             ->set(UserInterface::class, [
-                'username' => 'vimes',
+                'identity' => 'vimes',
                 'roles'    => ['captain'],
                 'details'  => ['gender' => 'male'],
             ])
@@ -202,7 +202,7 @@ class PhpSessionTest extends TestCase
             ->willReturn(false);
         $this->session
             ->set(UserInterface::class, [
-                'username' => 'foo',
+                'identity' => 'foo',
                 'roles'    => [],
                 'details'  => [],
             ])
@@ -241,7 +241,7 @@ class PhpSessionTest extends TestCase
         $phpSession = new PhpSession(
             $this->userRegister->reveal(),
             [
-                'username' => 'user',
+                'identity' => 'user',
                 'password' => 'pass',
             ],
             $this->responseFactory,
@@ -261,7 +261,7 @@ class PhpSessionTest extends TestCase
         $this->session
             ->get(UserInterface::class)
             ->willReturn([
-                'username' => 'vimes',
+                'identity' => 'vimes',
                 'roles'    => ['captain'],
                 'details'  => ['gender' => 'male'],
             ]);
@@ -342,7 +342,7 @@ class PhpSessionTest extends TestCase
             ->willReturn(false);
         $this->session
             ->set(UserInterface::class, [
-                'username' => 'foo',
+                'identity' => 'foo',
                 'roles'    => ['captain'],
                 'details'  => [],
             ])
@@ -381,7 +381,7 @@ class PhpSessionTest extends TestCase
         $phpSession = new PhpSession(
             $this->userRegister->reveal(),
             [
-                'username' => 'user',
+                'identity' => 'user',
                 'password' => 'pass',
             ],
             $this->responseFactory,


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | no
| BC Break      | yes
| New Feature   | no
| RFC           | no
| QA            | no

### Description
If we use the email field to sign in, then the name of the configuration is inconsistent. I change the parameter name `username -> identity`, but will remain by default `username`.

I think is breaking change, if we use (in configuration) for example `'username' => 'email'`.

I can't decide need fallback, but I think should drop.

```php
$username = $this->config['username'] ?? 'username';
$identity = $this->config['identity'] ?? $username;
```

Original suggestion: https://discourse.laminas.dev/t/use-identity-in-mezzio-authentication-session-instead-of-username/1290